### PR TITLE
Fix Flux Context Preset node not showing up in ComfyUI

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,35 +1,55 @@
-from .polymath import PolymathSettings, Polymath
-from .media_scraper import MediaScraper
-from .helper import SaveAbs, TextSplitter, StringListPicker
-#from .concept_eraser import ConceptEraserNode
-from .textmask import TextMaskNode
-from .flux_context_preset import FluxContextPreset
-#from .template import TemplateNode
+# Import FluxContextPreset first (always works)
+try:
+    from .flux_context_preset import FluxContextPreset
+except ImportError:
+    from flux_context_preset import FluxContextPreset
 
+# Initialize mappings with FluxContextPreset
 NODE_CLASS_MAPPINGS = {
-    "polymath_settings": PolymathSettings,
-    "polymath_chat": Polymath,
-    "polymath_scraper": MediaScraper,
-    "polymath_helper": SaveAbs,
-    "polymath_TextSplitter": TextSplitter,
-    "polymath_StringListPicker": StringListPicker,
-    "polymath_text_mask": TextMaskNode,
     "flux_context_preset": FluxContextPreset,
-    #"polymath_template": TemplateNode
-    #"polymath_concept_eraser": ConceptEraserNode,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "polymath_chat": "LLM Polymath Chat with Advanced Web and Link Search",
-    "polymath_scraper": "Media Scraper",
-    "polymath_helper": "Save Image to Absolute Path",
-    "polymath_TextSplitter": "Split Texts by Specified Delimiter",
-    "polymath_StringListPicker": "Picks Texts from a List by Index",
-    "polymath_text_mask": "Generate mask from text",
     "flux_context_preset": "Flux Context Preset",
-    "polymath_template": "Simple Node Template"
-    #"polymath_concept_eraser": "Erase Concept from Model"
 }
+
+# Try to import other nodes
+try:
+    try:
+        from .polymath import PolymathSettings, Polymath
+        from .media_scraper import MediaScraper
+        from .helper import SaveAbs, TextSplitter, StringListPicker
+        from .textmask import TextMaskNode
+    except ImportError:
+        from polymath import PolymathSettings, Polymath
+        from media_scraper import MediaScraper
+        from helper import SaveAbs, TextSplitter, StringListPicker
+        from textmask import TextMaskNode
+
+    # Add other nodes to mappings if imports successful
+    NODE_CLASS_MAPPINGS.update({
+        "polymath_settings": PolymathSettings,
+        "polymath_chat": Polymath,
+        "polymath_scraper": MediaScraper,
+        "polymath_helper": SaveAbs,
+        "polymath_TextSplitter": TextSplitter,
+        "polymath_StringListPicker": StringListPicker,
+        "polymath_text_mask": TextMaskNode,
+    })
+
+    NODE_DISPLAY_NAME_MAPPINGS.update({
+        "polymath_settings": "Polymath Settings",
+        "polymath_chat": "LLM Polymath Chat with Advanced Web and Link Search",
+        "polymath_scraper": "Media Scraper",
+        "polymath_helper": "Save Image to Absolute Path",
+        "polymath_TextSplitter": "Split Texts by Specified Delimiter",
+        "polymath_StringListPicker": "Picks Texts from a List by Index",
+        "polymath_text_mask": "Generate mask from text",
+    })
+
+except ImportError as e:
+    print(f"Warning: Some Polymath nodes could not be imported: {e}")
+    print("Only FluxContextPreset will be available.")
 
 ascii_art = """
 Polymath is brought to you by    

--- a/flux_context_preset.py
+++ b/flux_context_preset.py
@@ -185,11 +185,4 @@ Each line *is* a complete, concise instruction ready for the image editing AI. D
         
         return (selected_prompt,)
 
-# Node registration
-NODE_CLASS_MAPPINGS = {
-    "flux_context_preset": FluxContextPreset
-}
 
-NODE_DISPLAY_NAME_MAPPINGS = {
-    "flux_context_preset": "Flux Context Preset"
-}


### PR DESCRIPTION
## Problem
The Flux Context Preset node was not appearing in ComfyUI due to import issues and duplicate node mappings.

## Changes Made

### 1. Fixed Import Structure in `__init__.py`
- Updated import handling to support both relative and absolute imports
- Added robust error handling for missing dependencies
- Prioritized FluxContextPreset import to ensure it always loads

### 2. Improved Node Registration
- Ensured FluxContextPreset is registered first in NODE_CLASS_MAPPINGS
- Added proper display name mapping for all nodes including missing `polymath_settings`
- Used `.update()` method to add other nodes only if their imports succeed

### 3. Cleaned Up Duplicate Mappings
- Removed duplicate NODE_CLASS_MAPPINGS and NODE_DISPLAY_NAME_MAPPINGS from `flux_context_preset.py`
- Centralized all node registrations in the main `__init__.py` file

### 4. Enhanced Error Handling
- Added graceful fallback when some nodes can't be imported due to missing dependencies
- FluxContextPreset will always be available even if other nodes fail to load
- Clear warning messages for debugging import issues

## Files Changed
- `__init__.py`: Restructured imports and node registration with better error handling
- `flux_context_preset.py`: Removed duplicate node mappings

## Testing
- ✅ Verified FluxContextPreset imports and instantiates correctly
- ✅ Confirmed all 13 presets are available
- ✅ Tested node functionality with sample prompt generation
- ✅ Ensured proper ComfyUI integration
- ✅ Verified graceful handling of missing dependencies

## Result
The Flux Context Preset node now appears correctly in ComfyUI under "Polymath/Flux" category with:
- 13 different image transformation presets (Teleport, Move Camera, Relight, Product, Zoom, Colorize, Movie Poster, Cartoonify, Remove Text, Haircut, Bodybuilder, Remove Furniture, Interior Design)
- Additional text input for custom instructions
- JavaScript UI enhancements with preset modal
- Robust error handling

Fixes the issue where the node was not visible in the ComfyUI interface.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author